### PR TITLE
Added test for splitted sequence

### DIFF
--- a/phylofiller/test/data/assembly_simple_multi_line.fasta
+++ b/phylofiller/test/data/assembly_simple_multi_line.fasta
@@ -1,0 +1,4 @@
+> first
+AAAA
+> second
+AAAA

--- a/phylofiller/test/data/assembly_simple_single_line.fasta
+++ b/phylofiller/test/data/assembly_simple_single_line.fasta
@@ -1,0 +1,3 @@
+> first
+AAAA
+AAAA

--- a/phylofiller/test/data/assembly_with_splitted_entry.fasta
+++ b/phylofiller/test/data/assembly_with_splitted_entry.fasta
@@ -1,0 +1,35 @@
+>random sequence 1 consisting of 200 bases.
+tgcgtcgtgtattcttAACTAACCTCACGctacctgatagggtacttcaggggcgaccag
+tgaggggactttatcaaaccatattggcttcggattaagaattaa
+attagggggggggag
+tagttgatcctaagaccaaattatgcaaagatgacgagggtgtttcagtgacgacggggc
+tatacttagtgaatatgaag
+
+>random sequence 2 consisting of 200 bases.
+ttctccgccatgtgggtcgtcattcagtcccaactggcaggttgttgagagcttcaactg
+agtcgaaaggttaaccggattgtgcttagta
+
+>random sequence 3 consisting of 200 - x bases.
+tacgtccttcctgccttgacactcccaatgaagcacgctaaaaccagtcgatggtatgcctgcttgacgtggatcgtccgtgtaattcgacctg
+
+>random sequence 3.5 consisting of x bases.
+ttgccactaaatgcattgtcccaccccacctccactgtatctgtcacgagaagctccgatatttggagttcggcacgtgatgcgccaatcggactccgagagtaac
+
+
+
+>random sequence 4 consisting of 200 bases.
+taaacacacgatctttatcaaagccttttcgtaagctctgaacgcctagggagctggatg
+aatgcaaataccatcgctgtcatttaaattcgaacacagcagctgaaaacccaaattcgt
+gttttag
+aa
+ctttttagctctcgtgaacacttacactcaagacacccgcatttttagggg
+cccggctacgagggtcgtca
+
+>random sequence 5 consisting of 200 bases.
+T
+A
+G
+ACCCCAGAAGCTCTACCCCTCGTACAGGTGGCCCGCCTATCAACTACGTTGTCTAAC
+ATCTGCAATGTCATTTGCCGACGGCTCCGAATCAAGCCCCGGGTAATCATTTTTTGAGTG
+AAAGTGAAGAATCTACTACGGCCTCTCCAGGGATCGCCAGTACCGACAAGGGCGCAATCT
+ATCTGCGGAGACAACTAACG

--- a/phylofiller/test/test_io.py
+++ b/phylofiller/test/test_io.py
@@ -56,6 +56,13 @@ class IOTests(TestCase):
             self.exp_md5, obs_md5,
             "one additional sequence, should result in different MD5")
 
+        obs_md5 = get_assembly_checksum(get_data_path(
+            'assembly_with_splitted_entry.fasta'))
+        self.assertNotEqual(
+            self.exp_md5, obs_md5,
+            "one sequence splitted into two,"
+            "should result in different MD5")
+
 
 if __name__ == '__main__':
     main()

--- a/phylofiller/test/test_io.py
+++ b/phylofiller/test/test_io.py
@@ -63,6 +63,15 @@ class IOTests(TestCase):
             "one sequence splitted into two,"
             "should result in different MD5")
 
+        obs_md5 = get_assembly_checksum(get_data_path(
+            'assembly_simple_multi_line.fasta'))
+        obs2_md5 = get_assembly_checksum(get_data_path(
+            'assembly_simple_single_line.fasta'))
+        self.assertNotEqual(
+            obs2_md5, obs_md5,
+            "one sequence splitted into two identical,"
+            "should result in different MD5")
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Added simple tests, which guarantees different md5 checksums for non-identical sequences, which are identical after concatination.